### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/juayen/21abcd42-d8d6-4825-98eb-465fe5d8b1f4/34a3275b-de64-4370-87f4-800089cc3e9f/_apis/work/boardbadge/8baf89cf-a9d1-456a-bbb0-8902881237a2)](https://dev.azure.com/juayen/21abcd42-d8d6-4825-98eb-465fe5d8b1f4/_boards/board/t/34a3275b-de64-4370-87f4-800089cc3e9f/Microsoft.RequirementCategory)
 # fastapi-customers


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#159](https://dev.azure.com/juayen/21abcd42-d8d6-4825-98eb-465fe5d8b1f4/_workitems/edit/159). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.